### PR TITLE
Add Kanban board feature to Blazor project

### DIFF
--- a/Blazor.ProjectTracker/Components/Pages/ProjectDetail.razor
+++ b/Blazor.ProjectTracker/Components/Pages/ProjectDetail.razor
@@ -1,0 +1,32 @@
+﻿@page "/project/{ProjectId:int}"
+@using global::ProjectTracker.Application.Interfaces
+@using global::ProjectTracker.Application.Services
+@using global::ProjectTracker.Domain.Entities
+@inject IBoardService BoardService
+
+<MudText Typo="Typo.h4">Boards for Project @ProjectId</MudText>
+
+@foreach (var board in Boards)
+{
+    <MudText Typo="Typo.h6">@board.Name</MudText>
+    <KanbanBoard Groups="@board.Groups" OnIssueMoved="HandleIssueMoved" />
+}
+
+@code {
+    [Parameter] public int ProjectId { get; set; }
+    public Project Project { get; set; }
+
+    private List<Board> Boards { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var allBoards = await BoardService.GetAllAsync(default);
+        Boards = allBoards.Where(x => x.ProjectID == ProjectId).ToList();
+    }
+
+    private Task HandleIssueMoved((Issue issue, Group newGroup) change)
+    {
+        // Persist the change (optional)
+        return Task.CompletedTask;
+    }
+}

--- a/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanBoard.razor
+++ b/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanBoard.razor
@@ -1,0 +1,28 @@
+﻿@using System.Collections.ObjectModel
+@using global::ProjectTracker.Domain.Entities
+@using global::ProjectTracker.Application.Interfaces
+@using MudBlazor
+@inject IGroupService GroupService
+
+<MudPaper Class="d-flex overflow-x-auto p-4 gap-4" Style="min-height: 70vh;">
+    @foreach (var group in Groups)
+    {
+        <KanbanColumn Group="group" OnMoveIssue="MoveIssueAsync" />
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public ObservableCollection<Group> Groups { get; set; }
+    [Parameter] public EventCallback<(Issue issue, Group targetGroup)> OnIssueMoved { get; set; }
+
+    private async Task MoveIssueAsync(Issue issue, Group newGroup)
+    {
+        issue.GroupID = newGroup.Id;
+        await OnIssueMoved.InvokeAsync((issue, newGroup));
+    }
+
+    private async Task GetAllGroups()
+    {
+        
+    }
+}

--- a/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanCard.razor
+++ b/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanCard.razor
@@ -1,0 +1,37 @@
+﻿@using global::ProjectTracker.Domain.Entities
+@using global::ProjectTracker.Application.Services
+@using MudBlazor
+
+<MudPaper Class="pa-2 my-2" Elevation="2" Style="cursor: grab;" @oncontextmenu:preventDefault>
+    <MudText Typo="Typo.subtitle2">@Issue.Name</MudText>
+    <MudText Typo="Typo.caption">@Issue.Description</MudText>
+</MudPaper>
+
+@code {
+    [Parameter] public Issue Issue { get; set; }
+    [Parameter] public Group Group { get; set; }
+    [Parameter] public EventCallback<(Issue issue, Group targetGroup)> OnMove { get; set; }
+
+    // Placeholder: Implement drag-and-drop in next phase
+}
+
+<MudSelect @bind-Value="selectedGroupId" Label="Move to" Dense>
+    @foreach (var g in AllGroups)
+    {
+        <MudSelectItem Value="@g.Id">@g.Name</MudSelectItem>
+    }
+</MudSelect>
+
+<MudButton OnClick="Move">Move</MudButton>
+
+@code {
+    [Parameter] public List<Group> AllGroups { get; set; }
+    private int selectedGroupId;
+
+    private async Task Move()
+    {
+        var target = AllGroups.FirstOrDefault(g => g.Id == selectedGroupId);
+        if (target != null)
+            await OnMove.InvokeAsync((Issue, target));
+    }
+}

--- a/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanColumn.razor
+++ b/Blazor.ProjectTracker/Components/SharedComponents/Kanban/KanbanColumn.razor
@@ -1,0 +1,17 @@
+﻿@using global::ProjectTracker.Domain.Entities
+@using MudBlazor
+
+<MudPaper Class="p-3" Style="width: 300px; min-height: 500px;" Elevation="3">
+    <MudText Typo="Typo.h6">@Group.Name</MudText>
+    <MudDivider />
+
+    @foreach (var issue in Group.Issues)
+    {
+        <KanbanCard Issue="issue" Group="Group" OnMove="OnMoveIssue" />
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public Group Group { get; set; }
+    [Parameter] public EventCallback<(Issue issue, Group targetGroup)> OnMoveIssue { get; set; }
+}


### PR DESCRIPTION
Introduced a Kanban board to manage project issues:
- Updated Blazor.ProjectTracker.csproj to reference application and domain projects.
- Added ProjectDetail.razor to display boards for a project.
- Created KanbanBoard.razor to render groups as columns.
- Added KanbanColumn.razor to display issues within a group.
- Implemented KanbanCard.razor to represent individual issues.
- Enabled issue movement between groups with event callbacks.

# Conflicts:
#	Blazor.ProjectTracker/Blazor.ProjectTracker.csproj